### PR TITLE
whitlelist: Add /var/www/* & Fix whitespace handling for symlinks

### DIFF
--- a/lostfiles.py
+++ b/lostfiles.py
@@ -90,6 +90,7 @@ WHITELIST = {
     *glob("/usr/share/fonts/*/*.dir"),
     *glob("/usr/share/fonts/*/*.scale"),
     *glob("/usr/src/linux*"),  # Ignore kernel source directories
+    *glob("/var/www/*"),
 }
 
 

--- a/lostfiles.py
+++ b/lostfiles.py
@@ -180,13 +180,14 @@ def normalize_filenames(files: List[str]) -> Set[str]:
 
         elif ctype == "sym":
             # format: sym <source> -> <target> <unixtime>
-            parts = rem.split(" ")
-            assert len(parts) == 4, "unknown obj syntax definition for: %s" % f
+            parts = rem.split(" -> ")
+            assert len(parts) == 2, "unknown obj syntax definition for: %s" % f
             sym_origin = parts[0]
-            if parts[2].startswith("/"):
-                sym_target = parts[2]
+            sym_dest = parts[1].rsplit(" ", maxsplit=1)[0]
+            if sym_dest.startswith("/"):
+                sym_target = sym_dest
             else:
-                sym_target = os.path.join(os.path.dirname(sym_origin), parts[2])
+                sym_target = os.path.join(os.path.dirname(sym_origin), sym_dest)
             normalized.update(resolve_symlinks(sym_origin, sym_target))
 
         else:


### PR DESCRIPTION
- whitlelist: Add `/var/www/*` as it's default for custom webserver files

- Fix whitespace handling - resolves e.g. the following issue:
```
Traceback (most recent call last):
  File "./lostfiles.py", line 210, in <module>
    main()
  File "./lostfiles.py", line 120, in main
    tracked = collect_tracked_files()
  File "./lostfiles.py", line 202, in collect_tracked_files
    files.update(normalize_filenames(fp.readlines()))
  File "./lostfiles.py", line 183, in normalize_filenames
    assert len(parts) == 4, "unknown obj syntax definition for: %s" % f
AssertionError: unknown obj syntax definition for: sym /lib/firmware/brcm/brcmfmac43455-sdio.Raspberry Pi Foundation-Raspberry Pi 4 Model B.txt -> brcmfmac43455-sdio.raspberrypi,4-model-b.txt 1613309459
```