### PR TITLE
I include support for names in wrong utf8

### DIFF
--- a/lostfiles.py
+++ b/lostfiles.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import argparse
 import itertools
 import os
@@ -129,7 +131,7 @@ def main() -> None:
                 ]
 
             for name in filenames:
-                filepath = os.path.join(dirpath, name)
+                filepath = os.path.join(dirpath, name.encode('utf-8', 'replace').decode())
                 if any(f in tracked for f in resolve_symlinks(filepath)):
                     continue
                 if args.strict is False and should_ignore_path(filepath):


### PR DESCRIPTION
It fix this error:
---

Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.8/lostfiles", line 33, in <module>
    sys.exit(load_entry_point('lostfiles==0.2.2', 'console_scripts', 'lostfiles')())
  File "/usr/lib/python3.8/site-packages/lostfiles.py", line 138, in main
    print(filepath)
UnicodeEncodeError: 'utf-8' codec can't encode character '\udcf1' in position 27: surrogates not allowed

Signed-off-by: Fco Javier Felix <ffelix@inode64.com>