### PR TITLE
Skip keepfile if exception happens when parsing its name

### DIFF
--- a/lostfiles.py
+++ b/lostfiles.py
@@ -347,10 +347,13 @@ def process_directory(dirpath: str, filenames: list[str], strict: bool, tracked:
         if not name.startswith(".keep_"):
             continue
 
-        atom = resolve_pkg_from_keepfile(name)
-        if is_pkg_installed(atom):
-            raise IgnoreDirectory()
-        break
+        try:
+            atom = resolve_pkg_from_keepfile(name)
+            if is_pkg_installed(atom):
+                raise IgnoreDirectory()
+            break
+        except Exception:
+            pass
 
     if not strict:
         paths = resolve_symlinks(dirpath)


### PR DESCRIPTION
I've got the following exception because of file named '.keep_dir' being present in /usr/lib/ccache/bin:

```
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.11/lostfiles", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.11/site-packages/lostfiles.py", line 327, in main
    process_directory(dirpath, sorted(filenames), args.strict, tracked)
  File "/usr/lib/python3.11/site-packages/lostfiles.py", line 350, in process_directory
    atom = resolve_pkg_from_keepfile(name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/lostfiles.py", line 391, in resolve_pkg_from_keepfile
    _, category, remainder = filename.split("_", maxsplit=2)
    ^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 3, got 2)
```

It seems to me that the proper way would be to ignore presence of keepfiles which cannot be parsed for whatever reason and follow to the next suitable file if there is any.